### PR TITLE
Extract range queries and record iterator

### DIFF
--- a/src/main/java/org/janusgraph/diskstorage/foundationdb/FoundationDBRangeQuery.java
+++ b/src/main/java/org/janusgraph/diskstorage/foundationdb/FoundationDBRangeQuery.java
@@ -1,3 +1,17 @@
+// Copyright 2020 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package org.janusgraph.diskstorage.foundationdb;
 
 import com.apple.foundationdb.KeySelector;

--- a/src/main/java/org/janusgraph/diskstorage/foundationdb/FoundationDBRangeQuery.java
+++ b/src/main/java/org/janusgraph/diskstorage/foundationdb/FoundationDBRangeQuery.java
@@ -1,0 +1,44 @@
+package org.janusgraph.diskstorage.foundationdb;
+
+import com.apple.foundationdb.KeySelector;
+import com.apple.foundationdb.subspace.Subspace;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.keycolumnvalue.keyvalue.KVQuery;
+
+/**
+ * @author Florian Grieskamp
+ */
+public class FoundationDBRangeQuery {
+
+    private KVQuery originalQuery;
+    private KeySelector startKeySelector;
+    private KeySelector endKeySelector;
+    private int limit;
+
+    public FoundationDBRangeQuery(Subspace db, KVQuery kvQuery) {
+        originalQuery = kvQuery;
+        limit = kvQuery.getLimit();
+
+        byte[] startKey = db.pack(kvQuery.getStart().as(FoundationDBKeyValueStore.ENTRY_FACTORY));
+        byte[] endKey = db.pack(kvQuery.getEnd().as(FoundationDBKeyValueStore.ENTRY_FACTORY));
+
+        startKeySelector = KeySelector.firstGreaterOrEqual(startKey);
+        endKeySelector = KeySelector.firstGreaterOrEqual(endKey);
+    }
+
+    public void setStartKeySelector(KeySelector startKeySelector) {
+        this.startKeySelector = startKeySelector;
+    }
+
+    public void setEndKeySelector(KeySelector endKeySelector) {
+        this.endKeySelector = endKeySelector;
+    }
+
+    public KVQuery asKVQuery() { return originalQuery; }
+
+    public KeySelector getStartKeySelector() { return startKeySelector; }
+
+    public KeySelector getEndKeySelector() { return endKeySelector; }
+
+    public int getLimit() { return limit; }
+}

--- a/src/main/java/org/janusgraph/diskstorage/foundationdb/FoundationDBRecordIterator.java
+++ b/src/main/java/org/janusgraph/diskstorage/foundationdb/FoundationDBRecordIterator.java
@@ -1,3 +1,17 @@
+// Copyright 2020 JanusGraph Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package org.janusgraph.diskstorage.foundationdb;
 
 import com.apple.foundationdb.KeyValue;

--- a/src/main/java/org/janusgraph/diskstorage/foundationdb/FoundationDBRecordIterator.java
+++ b/src/main/java/org/janusgraph/diskstorage/foundationdb/FoundationDBRecordIterator.java
@@ -1,0 +1,42 @@
+package org.janusgraph.diskstorage.foundationdb;
+
+import com.apple.foundationdb.KeyValue;
+import com.apple.foundationdb.subspace.Subspace;
+import org.janusgraph.diskstorage.StaticBuffer;
+import org.janusgraph.diskstorage.keycolumnvalue.keyvalue.KeyValueEntry;
+import org.janusgraph.diskstorage.util.RecordIterator;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class FoundationDBRecordIterator implements RecordIterator<KeyValueEntry> {
+    private final Subspace ds;
+    private final Iterator<KeyValue> entries;
+
+    public FoundationDBRecordIterator(Subspace ds, final List<KeyValue> result) {
+        this.ds = ds;
+        this.entries = result.iterator();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return entries.hasNext();
+    }
+
+    @Override
+    public KeyValueEntry next() {
+        KeyValue nextKV = entries.next();
+        StaticBuffer key = FoundationDBKeyValueStore.getBuffer(ds.unpack(nextKV.getKey()).getBytes(0));
+        StaticBuffer value = FoundationDBKeyValueStore.getBuffer(nextKV.getValue());
+        return new KeyValueEntry(key, value);
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
Main changes:

1. Introduce the class `FoundationDBRangeQuery`
- This class replaces the old representation of range queries as `Object` arrays

2. Extract the `FoundationDBRecordIterator` into it's own file
- Unpacking the key-value pairs was also moved to the iterator class to keep the `FoundationDBKeyValueStore` class clean.