### PR TITLE
Handles truncated boundary keys

### DIFF
--- a/src/main/java/org/janusgraph/diskstorage/foundationdb/FoundationDBKeyValueStore.java
+++ b/src/main/java/org/janusgraph/diskstorage/foundationdb/FoundationDBKeyValueStore.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
@@ -257,10 +258,16 @@ public class FoundationDBKeyValueStore implements OrderedKeyValueStore, AutoClos
             throw new PermanentBackendException(e);
         }
     }
+
     public List<StaticBuffer> getBoundaryKeys() {
         List<StaticBuffer> keys = new ArrayList<>();
         try (CloseableAsyncIterator<byte[]> it = LocalityUtil.getBoundaryKeys(manager.db, db.range().begin, db.range().end)) {
-            it.forEachRemaining(key -> keys.add(getBuffer(db.unpack(key).getBytes(0))));
+            it.forEachRemaining(key -> {
+                if (key[key.length - 1] != 0x00) {
+                    key = Arrays.copyOf(key, key.length + 1);
+                }
+                keys.add(getBuffer(db.unpack(key).getBytes(0)));
+            });
         }
         return keys;
     }


### PR DESCRIPTION
Boundary keys might not be real keys:

https://github.com/apple/foundationdb/issues/3608

We need handle those truncated keys, or it will fail in FoundationDB 6.x client:

```
java.lang.IllegalArgumentException: No terminator found for bytes starting at 1
	at com.apple.foundationdb.tuple.TupleUtil$DecodeState.findNullTerminator(TupleUtil.java:98)
	at com.apple.foundationdb.tuple.TupleUtil.decode(TupleUtil.java:438)
	at com.apple.foundationdb.tuple.TupleUtil.unpack(TupleUtil.java:676)
	at com.apple.foundationdb.tuple.Tuple.fromBytes(Tuple.java:526)
	at com.apple.foundationdb.subspace.Subspace.unpack(Subspace.java:231)
	at org.janusgraph.diskstorage.foundationdb.FoundationDBKeyValueStore.lambda$getBoundaryKeys$1(FoundationDBKeyValueStore.java:264)
	at java.util.Iterator.forEachRemaining(Iterator.java:116)
	at org.janusgraph.diskstorage.foundationdb.FoundationDBKeyValueStore.getBoundaryKeys(FoundationDBKeyValueStore.java:264)
```