### PR TITLE
Remove trailing commas from yaml config

### DIFF
--- a/conf/gremlin-server.yaml
+++ b/conf/gremlin-server.yaml
@@ -41,11 +41,11 @@ processors:
 - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
 - { className: org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor, config: { cacheExpirationTime: 600000, cacheMaxSize: 1000 }}
 metrics:
-  consoleReporter: {enabled: true, interval: 180000},
-  csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv},
-  jmxReporter: {enabled: true},
-  slf4jReporter: {enabled: true, interval: 180000},
-  gangliaReporter: {enabled: false, interval: 180000, addressingMode: MULTICAST},
+  consoleReporter: {enabled: true, interval: 180000}
+  csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv}
+  jmxReporter: {enabled: true}
+  slf4jReporter: {enabled: true, interval: 180000}
+  gangliaReporter: {enabled: false, interval: 180000, addressingMode: MULTICAST}
   graphiteReporter: {enabled: false, interval: 180000}
 maxInitialLineLength: 4096
 maxHeaderSize: 8192


### PR DESCRIPTION
Actually, I'm not 100% sure that this is the correct fix to do as, according to `git annotate`, these lines are 3 years old, but with JanusGraph-0.5.2 I get the following error when starting the server:

```
74   [main] ERROR org.apache.tinkerpop.gremlin.server.GremlinServer  - Configuration file at conf/gremlin-server/gremlin-server.yaml could not be found or parsed properly. [while parsing a block mapping; expected <block end>, but found FlowEntry;  in 'reader', line 44, column 54:
     ... nabled: false, interval: 180000},                                         ^]
```

Removal of the trailing commas resolved the issue for me.