### PR TITLE
Upgrade dependencies to fix image pull error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
     <name>JanusGraph FoundationDB Storage Adapter</name>
 
     <properties>
-        <maven.compiler.plugin.version>3.6.2</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <jdk.version>1.8</jdk.version>
         <janusgraph.version>0.5.2</janusgraph.version>
         <foundationdb.version>6.2.22</foundationdb.version>
-        <dependency.plugin.version>2.10</dependency.plugin.version>
+        <dependency.plugin.version>3.2.0</dependency.plugin.version>
         <test.skip.default>false</test.skip.default>
         <test.skip.tp>true</test.skip.tp>
-        <testcontainers.version>1.14.3</testcontainers.version>
+        <testcontainers.version>1.15.3</testcontainers.version>
     </properties>
 
     <developers>

--- a/src/test/java/org/janusgraph/FoundationDBContainer.java
+++ b/src/test/java/org/janusgraph/FoundationDBContainer.java
@@ -40,7 +40,7 @@ public class FoundationDBContainer extends FixedHostPortGenericContainer<Foundat
 
     private final Logger log = LoggerFactory.getLogger(FoundationDBContainer.class);
 
-    public static final String DEFAULT_IMAGE_AND_TAG = "foundationdb/foundationdb:6.2.20";
+    public static final String DEFAULT_IMAGE_AND_TAG = "foundationdb/foundationdb:6.2.30";
     private static final Integer DEFAULT_PORT = 4500;
     private static final String FDB_CLUSTER_FILE_ENV_KEY = "FDB_CLUSTER_FILE";
     private static final String FDB_NETWORKING_MODE_ENV_KEY = "FDB_NETWORKING_MODE";


### PR DESCRIPTION
After merging #56, the master build broke because of https://github.com/testcontainers/testcontainers-java/issues/3574.
This bug is fixed in more recent versions of testcontainers.